### PR TITLE
Updates bucket versioning Config -- SGINT-438

### DIFF
--- a/.config/.terraform-docs.yml
+++ b/.config/.terraform-docs.yml
@@ -5,7 +5,7 @@ formatter: markdown table
 name: terraform-aws-cloudtrail
 
 content: |-
-  # Terraform AWS Template
+  # terraform-aws-cloudtrail
 
   GitHub: [StratusGrid/terraform-aws-cloudtrail](https://github.com/StratusGrid/terraform-aws-cloudtrail)
 
@@ -33,17 +33,15 @@ content: |-
   - Wesley Kirkland [wesleykirklandsg](https://github.com/wesleykirklandsg)
   - Module originally forked from [Quinovas](https://github.com/QuiNovas)
 
-  <span style="color:red">Notes</span>
-
-  - Manual changes to the README will be overwritten when the documentation is updated. To update the documentation, run `terraform-docs -c .config/.terraform-docs.yml .`
-  - TF Docs in 0.16.0 is bugged and doesn't handle indentation, reference files in `examples/*` will need to be used for indentention.
+  <span style="color:red">Note:</span> Manual changes to the README will be overwritten when the documentation is updated. To update the documentation, run `terraform-docs -c .config/.terraform-docs.yml .`
 
 sections:
   show:
-    - requirements
     - resources
     - inputs
     - outputs
+    - providers
+    - requirements
 
 sort:
   enabled: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- BEGIN_TF_DOCS -->
-# Terraform AWS Template
+# terraform-aws-cloudtrail
 
 GitHub: [StratusGrid/terraform-aws-cloudtrail](https://github.com/StratusGrid/terraform-aws-cloudtrail)
 
@@ -10,10 +10,12 @@ This module sets up CloudTrail for an AWS account, including writing to CloudWat
 ```hcl
 module "cloudtrail" {
   source = "StratusGrid/cloudtrail/aws"
-  version = "3.0.0"
-  
+  # StratusGrid recommends pinning every module to a specific version
+  version = "x.x.x"
+
   name_prefix = var.name_prefix
   log_bucket  = module.s3_bucket_logging.bucket_id
+
   input_tags  = merge(local.common_tags, {})
 }
 ```
@@ -24,6 +26,7 @@ module "cloudtrail" {
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Resources
@@ -80,8 +83,5 @@ module "cloudtrail" {
 - Wesley Kirkland [wesleykirklandsg](https://github.com/wesleykirklandsg)
 - Module originally forked from [Quinovas](https://github.com/QuiNovas)
 
-<span style="color:red">Notes</span>
-
-- Manual changes to the README will be overwritten when the documentation is updated. To update the documentation, run `terraform-docs -c .config/.terraform-docs.yml .`
-- TF Docs in 0.16.0 is bugged and doesn't handle indentation, reference files in `examples/*` will need to be used for indentention.
+<span style="color:red">Note:</span> Manual changes to the README will be overwritten when the documentation is updated. To update the documentation, run `terraform-docs -c .config/.terraform-docs.yml .`
 <!-- END_TF_DOCS -->

--- a/examples/example1.tfnot
+++ b/examples/example1.tfnot
@@ -1,8 +1,10 @@
 module "cloudtrail" {
   source = "StratusGrid/cloudtrail/aws"
-  version = "3.0.0"
-  
+  # StratusGrid recommends pinning every module to a specific version
+  version = "x.x.x"
+
   name_prefix = var.name_prefix
   log_bucket  = module.s3_bucket_logging.bucket_id
+
   input_tags  = merge(local.common_tags, {})
 }

--- a/s3-bucket.tf
+++ b/s3-bucket.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket_versioning" "resource" {
   bucket = aws_s3_bucket.cloudtrail.id
 
   versioning_configuration {
-    status     = "Disabled"
+    status     = "Enabled"
     mfa_delete = var.enable_mfa_delete_cloudtrail_bucket == true ? "Enabled" : "Disabled"
   }
 }

--- a/s3-bucket.tf
+++ b/s3-bucket.tf
@@ -5,7 +5,6 @@ resource "aws_s3_bucket" "cloudtrail" {
   tags = merge(local.common_tags, {})
 }
 
-#tfsec:ignore:aws-s3-enable-versioning -- Ignore warning on versioning
 resource "aws_s3_bucket_versioning" "resource" {
   bucket = aws_s3_bucket.cloudtrail.id
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.3"
+
   required_providers {
     aws = {
       version = ">= 4.0"


### PR DESCRIPTION
## Change description

> Bucket versioning is now set to "Enabled" to avoid the api error of Malformed XML when "mfa_delete" is added while versioning is "Disabled." This change also updates the documentation of the module and adds a terraform required version attribute.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
